### PR TITLE
Fix superfluous exception when socket read returns less than the requ…

### DIFF
--- a/src/main/java/com/neovisionaries/ws/client/WebSocketInputStream.java
+++ b/src/main/java/com/neovisionaries/ws/client/WebSocketInputStream.java
@@ -141,15 +141,21 @@ class WebSocketInputStream extends FilterInputStream
     private void readBytes(byte[] buffer, int length) throws IOException, WebSocketException
     {
         // Read
-        int count = read(buffer, 0, length);
-
-        if (count != length)
-        {
-            // The end of the stream has been reached unexpectedly.
-            throw new WebSocketException(
-                WebSocketError.INSUFFICENT_DATA,
-                "The end of the stream has been reached unexpectedly.");
-        }
+    	int total = 0;
+    	while (total < length)
+    	{
+    		int count = read(buffer, total, length-total);
+    		
+	        if (count <= 0)
+	        {
+	            // The end of the stream has been reached unexpectedly.
+	            throw new WebSocketException(
+	                WebSocketError.INSUFFICENT_DATA,
+	                "The end of the stream has been reached unexpectedly.");
+	        }
+	        
+	        total += count;
+    	}
     }
 
 


### PR DESCRIPTION
…ested number of bytes

This problem was observed when using the implementation on Motorola MotoG and MotoE phones. The initial call to read(buffer, 0, length) with a 3-byte request would only return 1 byte. This would result in a WebSocketException and closing of the socket. However, a subsequent call to read() would return the remaining bytes.