### PR TITLE
Added code that sets proper position in underlying ByteBuffer object during expanding, shrinking and clearing of ByteArray.

### DIFF
--- a/src/main/java/com/neovisionaries/ws/client/ByteArray.java
+++ b/src/main/java/com/neovisionaries/ws/client/ByteArray.java
@@ -94,8 +94,10 @@ class ByteArray
         ByteBuffer newBuffer = ByteBuffer.allocate(newBufferSize);
 
         // Copy the content of the current buffer to the new buffer.
+        int oldPosition = mBuffer.position();
         mBuffer.position(0);
         newBuffer.put(mBuffer);
+        newBuffer.position(oldPosition);
 
         // Replace the buffers.
         mBuffer = newBuffer;
@@ -220,6 +222,7 @@ class ByteArray
     public void clear()
     {
         mBuffer.clear();
+        mBuffer.position(0);
         mLength = 0;
     }
 
@@ -237,6 +240,7 @@ class ByteArray
         byte[] bytes = toBytes(beginIndex, endIndex);
 
         mBuffer = ByteBuffer.wrap(bytes);
+        mBuffer.position(bytes.length);
         mLength = bytes.length;
     }
 


### PR DESCRIPTION
While using deflate extension for websocket I noticed that messages from server weren't decompressed correctly and I often did get BufferOverflowException from ByteBuffer object. Changes visible in PR are fixing those issues.