### PR TITLE
Added Android-compatibile support for SNI in direct connections

### DIFF
--- a/src/main/java/com/neovisionaries/ws/client/OkHostnameVerifier.java
+++ b/src/main/java/com/neovisionaries/ws/client/OkHostnameVerifier.java
@@ -68,6 +68,11 @@ final class OkHostnameVerifier implements HostnameVerifier {
     }
   }
 
+  public boolean verifyWithExc(String host, SSLSession session) throws SSLException {
+      Certificate[] certificates = session.getPeerCertificates();
+      return verify(host, (X509Certificate) certificates[0]);
+  }
+
   public boolean verify(String host, X509Certificate certificate) {
     return verifyAsIpAddress(host)
         ? verifyIpAddress(host, certificate)

--- a/src/main/java/com/neovisionaries/ws/client/ProxyHandshaker.java
+++ b/src/main/java/com/neovisionaries/ws/client/ProxyHandshaker.java
@@ -28,32 +28,30 @@ import java.util.Map;
 class ProxyHandshaker
 {
     private static final String RN = "\r\n";
-    private final Socket mSocket;
     private final String mHost;
     private final int mPort;
     private final ProxySettings mSettings;
 
 
-    public ProxyHandshaker(Socket socket, String host, int port, ProxySettings settings)
+    public ProxyHandshaker(String host, int port, ProxySettings settings)
     {
-        mSocket   = socket;
         mHost     = host;
         mPort     = port;
         mSettings = settings;
     }
 
 
-    public void perform() throws IOException
+    public void perform(Socket socket) throws IOException
     {
         // Send a CONNECT request to the proxy server.
-        sendRequest();
+        sendRequest(socket);
 
         // Receive a response.
-        receiveResponse();
+        receiveResponse(socket);
     }
 
 
-    private void sendRequest() throws IOException
+    private void sendRequest(Socket socket) throws IOException
     {
         // Build a CONNECT request.
         String request = buildRequest();
@@ -62,7 +60,7 @@ class ProxyHandshaker
         byte[] requestBytes = Misc.getBytesUTF8(request);
 
         // Get the stream to send data to the proxy server.
-        OutputStream output = mSocket.getOutputStream();
+        OutputStream output = socket.getOutputStream();
 
         // Send the request to the proxy server.
         output.write(requestBytes);
@@ -140,10 +138,10 @@ class ProxyHandshaker
     }
 
 
-    private void receiveResponse() throws IOException
+    private void receiveResponse(Socket socket) throws IOException
     {
         // Get the stream to read data from the proxy server.
-        InputStream input = mSocket.getInputStream();
+        InputStream input = socket.getInputStream();
 
         // Read the status line.
         readStatusLine(input);

--- a/src/main/java/com/neovisionaries/ws/client/WebSocketFactory.java
+++ b/src/main/java/com/neovisionaries/ws/client/WebSocketFactory.java
@@ -588,14 +588,11 @@ public class WebSocketFactory
         // Select a socket factory.
         SocketFactory socketFactory = mProxySettings.selectSocketFactory();
 
-        // Let the socket factory create a socket.
-        Socket socket = socketFactory.createSocket();
-
         // The address to connect to.
         Address address = new Address(mProxySettings.getHost(), proxyPort);
 
         // The delegatee for the handshake with the proxy.
-        ProxyHandshaker handshaker = new ProxyHandshaker(socket, host, port, mProxySettings);
+        ProxyHandshaker handshaker = new ProxyHandshaker(host, port, mProxySettings);
 
         // SSLSocketFactory for SSL handshake with the WebSocket endpoint.
         SSLSocketFactory sslSocketFactory = secure ?
@@ -603,7 +600,7 @@ public class WebSocketFactory
 
         // Create an instance that will execute the task to connect to the server later.
         return new SocketConnector(
-                socket, address, timeout, handshaker, sslSocketFactory, host, port);
+                socketFactory, address, timeout, handshaker, sslSocketFactory, host, port);
     }
 
 
@@ -612,14 +609,11 @@ public class WebSocketFactory
         // Select a socket factory.
         SocketFactory factory = mSocketFactorySettings.selectSocketFactory(secure);
 
-        // Let the socket factory create a socket.
-        Socket socket = factory.createSocket();
-
         // The address to connect to.
         Address address = new Address(host, port);
 
         // Create an instance that will execute the task to connect to the server later.
-        return new SocketConnector(socket, address, timeout);
+        return new SocketConnector(factory, address, timeout);
     }
 
 


### PR DESCRIPTION
This PR is not meant for direct merging, but rather for a discussion; the problem is that the API for SNI is available in Java8/Android API24 (the 'correct' implementation is in my branch https://github.com/ondrap/nv-websocket-client/tree/android-api24 ). This PR is rather slight refactoring that results in correct behaviour for direct connections on Android systems and possibly plain Java (tested with Java8). SNI in this case doesn't work for proxied connections as there is no API available to do that.

There is a slight drawback though, as there is no way to set connectionTimeout with the `createSocket()` call, so the system default is used. I'm OK with that for my use, however I am not sure if such a change is appropriate for the library.