### PR TITLE
Daemonize timer threads in ReadingThread, fixes #140

### DIFF
--- a/src/main/java/com/neovisionaries/ws/client/ReadingThread.java
+++ b/src/main/java/com/neovisionaries/ws/client/ReadingThread.java
@@ -1146,7 +1146,7 @@ class ReadingThread extends WebSocketThread
     private void scheduleCloseTask()
     {
         mCloseTask  = new CloseTask();
-        mCloseTimer = new Timer("ReadingThreadCloseTimer");
+        mCloseTimer = new Timer("ReadingThreadCloseTimer", true);
         mCloseTimer.schedule(mCloseTask, mCloseDelay);
     }
 


### PR DESCRIPTION
I don't have a full understanding of ReadingThread or why the Timer's task isn't completing, but daemonizing the timer's thread fixes the hang for me.