### PR TITLE
Cancel close timer after task execution

### DIFF
--- a/src/main/java/com/neovisionaries/ws/client/ReadingThread.java
+++ b/src/main/java/com/neovisionaries/ws/client/ReadingThread.java
@@ -1199,6 +1199,17 @@ class ReadingThread extends WebSocketThread
             {
                 // Ignore.
             }
+            finally
+            {
+                synchronized (mCloseLock)
+                {
+                    if (mCloseTimer != null)
+                    {
+                        mCloseTimer.cancel();
+                        mCloseTimer = null;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #140 

When `WebSocket.disconnec(closeCode, reason, closeDelay)` is called and the close frame is not received from the server, the `CloseTask` fires.

However, in this case, no `cancelCloseTask` is called, leading to leave the thread from the close timer waiting for a new task.

Solution: If `CloseTask` fires, cancel the timer since it is used for a one time scheduling only.

As stated in the [`Timer`](https://docs.oracle.com/javase/7/docs/api/java/util/Timer.html#cancel()) Javadoc, it is safe to cancel within the task