### PR TITLE
Add copy constructor to WebSocketFactory

### DIFF
--- a/src/main/java/com/neovisionaries/ws/client/ProxySettings.java
+++ b/src/main/java/com/neovisionaries/ws/client/ProxySettings.java
@@ -100,6 +100,21 @@ public class ProxySettings
         reset();
     }
 
+    void apply(ProxySettings settings)
+    {
+        mHeaders.putAll(settings.mHeaders);
+        mSecure = settings.mSecure;
+        mHost   = settings.mHost;
+        mPort   = settings.mPort;
+        mId     = settings.mId;
+        mPassword = settings.mPassword;
+        if (settings.mServerNames != null)
+        {
+            mServerNames = new String[settings.mServerNames.length];
+            System.arraycopy(settings.mServerNames, 0, mServerNames, 0, mServerNames.length);
+        }
+    }
+
 
     /**
      * Get the associated {@link WebSocketFactory} instance.

--- a/src/main/java/com/neovisionaries/ws/client/ProxySettings.java
+++ b/src/main/java/com/neovisionaries/ws/client/ProxySettings.java
@@ -100,13 +100,15 @@ public class ProxySettings
         reset();
     }
 
-    void apply(ProxySettings settings)
+
+    ProxySettings(WebSocketFactory factory, ProxySettings settings)
     {
+        this(factory);
         mHeaders.putAll(settings.mHeaders);
-        mSecure = settings.mSecure;
-        mHost   = settings.mHost;
-        mPort   = settings.mPort;
-        mId     = settings.mId;
+        mSecure   = settings.mSecure;
+        mHost     = settings.mHost;
+        mPort     = settings.mPort;
+        mId       = settings.mId;
         mPassword = settings.mPassword;
         if (settings.mServerNames != null)
         {

--- a/src/main/java/com/neovisionaries/ws/client/SocketFactorySettings.java
+++ b/src/main/java/com/neovisionaries/ws/client/SocketFactorySettings.java
@@ -27,6 +27,16 @@ class SocketFactorySettings
     private SSLSocketFactory mSSLSocketFactory;
     private SSLContext mSSLContext;
 
+    public SocketFactorySettings() {}
+
+
+    public SocketFactorySettings(SocketFactorySettings settings)
+    {
+        mSocketFactory = settings.mSocketFactory;
+        mSSLSocketFactory = settings.mSSLSocketFactory;
+        mSSLContext = settings.mSSLContext;
+    }
+
 
     public SocketFactory getSocketFactory()
     {

--- a/src/main/java/com/neovisionaries/ws/client/WebSocketFactory.java
+++ b/src/main/java/com/neovisionaries/ws/client/WebSocketFactory.java
@@ -46,6 +46,36 @@ public class WebSocketFactory
         mProxySettings         = new ProxySettings(this);
     }
 
+    /**
+     * Creates a WebSocketFactory with settings copied from the provided factory.
+     *
+     * @param other
+     *         A WebSocketFactory to copy
+     *
+     * @throws IllegalArgumentException
+     *          If the given WebSocketFactory is null.
+     */
+    public WebSocketFactory(WebSocketFactory other)
+    {
+        if (other == null)
+        {
+            throw new IllegalArgumentException("The given WebSocketFactory is null");
+        }
+
+        mSocketFactorySettings  = new SocketFactorySettings(other.mSocketFactorySettings);
+        mProxySettings          = new ProxySettings(this);
+        mConnectionTimeout      = other.mConnectionTimeout;
+        mDualStackMode          = other.mDualStackMode;
+        mDualStackFallbackDelay = other.mDualStackFallbackDelay;
+        mVerifyHostname         = other.mVerifyHostname;
+        mProxySettings.apply(other.mProxySettings);
+        if (other.mServerNames != null)
+        {
+            mServerNames = new String[other.mServerNames.length];
+            System.arraycopy(other.mServerNames, 0, mServerNames, 0, mServerNames.length);
+        }
+    }
+
 
     /**
      * Get the socket factory that has been set by {@link

--- a/src/main/java/com/neovisionaries/ws/client/WebSocketFactory.java
+++ b/src/main/java/com/neovisionaries/ws/client/WebSocketFactory.java
@@ -46,6 +46,7 @@ public class WebSocketFactory
         mProxySettings         = new ProxySettings(this);
     }
 
+
     /**
      * Creates a WebSocketFactory with settings copied from the provided factory.
      *
@@ -63,12 +64,11 @@ public class WebSocketFactory
         }
 
         mSocketFactorySettings  = new SocketFactorySettings(other.mSocketFactorySettings);
-        mProxySettings          = new ProxySettings(this);
+        mProxySettings          = new ProxySettings(this, other.mProxySettings);
         mConnectionTimeout      = other.mConnectionTimeout;
         mDualStackMode          = other.mDualStackMode;
         mDualStackFallbackDelay = other.mDualStackFallbackDelay;
         mVerifyHostname         = other.mVerifyHostname;
-        mProxySettings.apply(other.mProxySettings);
         if (other.mServerNames != null)
         {
             mServerNames = new String[other.mServerNames.length];


### PR DESCRIPTION
I've added a copy-constructor to the WebSocketFactory which allows using it in a more diverse way to create sockets with the same base settings.

Example:

```java
WebSocketFactory factory = getBaseFactory(); // stored factory with base settings such as connect timeout

factory = new WebSocketFactory(factory); // settings copied over
factory.setServerName("example.com"); // apply new settings
System.out.println(factory.getServerNames() == getBaseFactory().getServerNames()); // false
```


Closes #201 