### PR TITLE
The "HOST" value in standard http header can not contain port.

### DIFF
--- a/src/main/java/com/neovisionaries/ws/client/HandshakeBuilder.java
+++ b/src/main/java/com/neovisionaries/ws/client/HandshakeBuilder.java
@@ -50,9 +50,11 @@ class HandshakeBuilder
         mUri = URI.create(String.format("%s://%s%s",
             (secure ? "wss" : "ws"), host, path));
 
+        boolean hidePort = ((mSecure && mUri.getPort() == 443) || (!mSecure && mUri.getPort() == 80));
+
         mSecure   = secure;
         mUserInfo = userInfo;
-        mHost     = mUri.getHost();
+        mHost     = hidePort ? mUri.getHost() : mUri.getHost() + ":" + mUri.getPort();
         mPath     = path;
     }
 

--- a/src/main/java/com/neovisionaries/ws/client/HandshakeBuilder.java
+++ b/src/main/java/com/neovisionaries/ws/client/HandshakeBuilder.java
@@ -44,15 +44,16 @@ class HandshakeBuilder
 
     public HandshakeBuilder(boolean secure, String userInfo, String host, String path)
     {
-        mSecure   = secure;
-        mUserInfo = userInfo;
-        mHost     = host;
-        mPath     = path;
 
         // 'host' may contain ':{port}' at its end.
         // 'path' may contain '?{query}' at its end.
         mUri = URI.create(String.format("%s://%s%s",
             (secure ? "wss" : "ws"), host, path));
+
+        mSecure   = secure;
+        mUserInfo = userInfo;
+        mHost     = mUri.getHost();
+        mPath     = path;
     }
 
 


### PR DESCRIPTION
Use the port in the Host header when you use a non-default port.
